### PR TITLE
feat: add email validation to CreateCustomer endpoint

### DIFF
--- a/GraphOfOrders.Api/GraphOfOrders.Api.csproj
+++ b/GraphOfOrders.Api/GraphOfOrders.Api.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
+    <PackageReference Include="FluentValidation" Version="11.10.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.11">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/GraphOfOrders.Api/IoC/ValidatorCollectionExtensions.cs
+++ b/GraphOfOrders.Api/IoC/ValidatorCollectionExtensions.cs
@@ -1,0 +1,14 @@
+using GraphOfOrders.Api.Validator;
+using GraphOfOrders.Lib.DI.Validator;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GraphOfOrders.Api.IoC;
+
+public static class ValidatorCollectionExtensions
+{
+    public static IServiceCollection AddValidatorServices(this IServiceCollection services)
+    {
+        services.AddScoped<IEmailValidator, EmailValidator>();
+        return services;
+    }
+}

--- a/GraphOfOrders.Api/Program.cs
+++ b/GraphOfOrders.Api/Program.cs
@@ -1,3 +1,4 @@
+using GraphOfOrders.Api.IoC;
 using GraphOfOrders.Repo.IoC;
 using GraphOfOrders.Service.IoC;
 using GraphOfOrders.Service;
@@ -9,6 +10,7 @@ builder.Services.AddAutoMapper(typeof(MappingProfile).Assembly);
 // Add services to the container.
 builder.Services.AddRepoServices(builder.Configuration);
 builder.Services.AddBusinessServices();
+builder.Services.AddValidatorServices();
 
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
@@ -36,4 +38,6 @@ app.MapControllers();
 app.Run();
 
 // Make the implicit Program class public so test projects can access it
-public partial class Program { }
+public partial class Program
+{
+}

--- a/GraphOfOrders.Api/Valitator/EmailValidator.cs
+++ b/GraphOfOrders.Api/Valitator/EmailValidator.cs
@@ -1,0 +1,23 @@
+using FluentValidation;
+using FluentValidation.Results;
+using GraphOfOrders.Lib.DI.Validator;
+using GraphOfOrders.Lib.DTOs;
+
+namespace GraphOfOrders.Api.Validator;
+
+
+public class EmailValidator : AbstractValidator<CustomerInputDTO>, IEmailValidator
+{
+    public EmailValidator()
+    {
+        RuleFor(customer => customer.Email)
+            .NotEmpty().WithMessage("Email is required.")
+            .EmailAddress().WithMessage("Invalid email format.");
+    }
+    
+    public async Task<ValidationResult> ValidateEmail(CustomerInputDTO customer)
+    {
+        return await ValidateAsync(customer);
+    }
+}
+

--- a/GraphOfOrders.Api/appsettings.json
+++ b/GraphOfOrders.Api/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost;Port=5432;Database=graphdb;Username=user;Password=changeme"
+    "DefaultConnection": "Server=localhost;Port=5433;Database=graphdb;Username=user;Password=changeme"
   },
   "Logging": {
     "LogLevel": {

--- a/GraphOfOrders.Lib/DI/Validator/IEmailValidator.cs
+++ b/GraphOfOrders.Lib/DI/Validator/IEmailValidator.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+using FluentValidation.Results;
+using GraphOfOrders.Lib.DTOs;
+
+namespace GraphOfOrders.Lib.DI.Validator
+{
+    public interface IEmailValidator
+    {
+        Task<ValidationResult> ValidateEmail(CustomerInputDTO customer);
+    }
+}

--- a/GraphOfOrders.Lib/GraphOfOrders.Lib.csproj
+++ b/GraphOfOrders.Lib/GraphOfOrders.Lib.csproj
@@ -4,4 +4,8 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="11.10.0" />
+  </ItemGroup>
+
 </Project>

--- a/GraphOfOrders.Test/Domains/Customer/CustomerEmailValidator.cs
+++ b/GraphOfOrders.Test/Domains/Customer/CustomerEmailValidator.cs
@@ -1,0 +1,88 @@
+using FluentValidation.TestHelper;
+using GraphOfOrders.Lib.DTOs;
+using GraphOfOrders.Api.Validator;
+using Xunit;
+
+namespace GraphOfOrders.Test.Domains.Customer;
+
+public class CustomerEmailValidator
+{
+    private readonly EmailValidator _validator;
+
+    public CustomerEmailValidator()
+    {
+        _validator = new EmailValidator();
+    }
+    
+    [Fact]
+    public void Should_Have_Error_When_Email_Is_Empty()
+    {
+        // Arrange
+        var customerDto = new CustomerInputDTO { Email = "" };
+
+        // Act & Assert
+        var result = _validator.TestValidate(customerDto);
+        result.ShouldHaveValidationErrorFor(customer => customer.Email)
+            .WithErrorMessage("Email is required.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Email_Is_Null()
+    {
+        // Arrange
+        var customerDto = new CustomerInputDTO { Email = null };
+        
+        // Act & Assert
+        var result = _validator.TestValidate(customerDto);
+        result.ShouldHaveValidationErrorFor(customer => customer.Email)
+            .WithErrorMessage("Email is required.");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Email_Is_Not_Valid()
+    {
+        // Arrange
+        var customerDto = new CustomerInputDTO { Email = "testtest.com" };
+        
+        // Act & Action
+        var result = _validator.TestValidate(customerDto);
+        result.ShouldHaveValidationErrorFor(customer => customer.Email)
+            .WithErrorMessage("Invalid email format.");
+    }
+    
+    [Fact]
+    public void Should_Have_Error_When_Symbol_Is_In_Beginning()
+    {
+        // Arrange
+        var customerDto = new CustomerInputDTO { Email = "@test.com" };
+        
+        // Act & Action
+        var result = _validator.TestValidate(customerDto);
+        result.ShouldHaveValidationErrorFor(customer => customer.Email)
+            .WithErrorMessage("Invalid email format.");
+    }
+    
+    [Fact]
+    public void Should_Have_Error_When_Symbol_Is_In_End()
+    {
+        // Arrange
+        var customerDto = new CustomerInputDTO { Email = "@test.com" };
+        
+        // Act & Action
+        var result = _validator.TestValidate(customerDto);
+        result.ShouldHaveValidationErrorFor(customer => customer.Email)
+            .WithErrorMessage("Invalid email format.");
+    }
+    
+    [Fact]
+    public void Should_Not_Have_Error_When_Email_Is_Valid()
+    {
+        // Arrange
+        var customerDto = new CustomerInputDTO { Email = "test@test.com" };
+        
+        // Act & Assert
+        var result = _validator.TestValidate(customerDto);
+        result.ShouldNotHaveValidationErrorFor(customer => customer.Email);
+    }
+    
+}


### PR DESCRIPTION
### Description
This pull request adds an email validation to the `CreateCustomer` endpoint, using FluentValidation to ensure the email field is present and properly formatted.
